### PR TITLE
Remove doc from cache when removed from the remote collection

### DIFF
--- a/lib/firestore_collection.dart
+++ b/lib/firestore_collection.dart
@@ -207,6 +207,7 @@ class FirestoreCollection {
         log('changed: ${change.doc.id}. type: ${change.type}. exist: ${change.doc.exists}.');
         if (change.type == DocumentChangeType.removed) {
           log('removed document change.');
+		  _removeDoc(change.doc.id);
           return;
         }
         if (shouldUpdate?.call(change.doc, change.doc) ?? true) {
@@ -253,9 +254,7 @@ class FirestoreCollection {
 
   Future<void> removeID(String documentID) async {
     await _removeOperation(documentID);
-    _docs.removeWhere((DocumentSnapshot doc) => doc.id == documentID);
-    _displayDocs?.removeWhere((DocumentSnapshot doc) => doc.id == documentID);
-    _streamController?.add(documents);
+    _removeDoc(documentID);
   }
 
   Future<void> removeSelecteds() async {
@@ -306,6 +305,12 @@ class FirestoreCollection {
     onItemRemoved?.call(documentID);
   }
 
+  Future<void> _removeDoc(String documentID) async {
+    _docs?.removeWhere((DocumentSnapshot doc) => doc.id == documentID);
+    _displayDocs?.removeWhere((DocumentSnapshot doc) => doc.id == documentID);
+    _streamController?.add(documents);
+  }
+  
   bool containsId(String documentID) {
     return _docs.any((element) => element.id == documentID);
   }


### PR DESCRIPTION
Just found that when a change is detected and `if (change.type == DocumentChangeType.removed)` is only logging but not doing anything in the local cache.